### PR TITLE
Changed how LDAP 'DN' attributes are used

### DIFF
--- a/active-directory/1.0.0/api.yaml
+++ b/active-directory/1.0.0/api.yaml
@@ -1,4 +1,4 @@
-app_version: 1.0.0
+app_version: 1.0.1
 name: Active Directory
 description: Active Directory and LDAP/LDAPS. For full usage of the action configure using LDAPS.
 contact_info:


### PR DESCRIPTION
The user's DN was constructed by retrieving the LDAP user attributes and concatenating 'CN + samAccountName + baseDN'. 

Functions change_password_at_next_logon(), enable_user() and disable_user() fail in certain environments due to the use of samAccountName. 

A better construction is to use the DN as retrieved by user_attributes() directly. Tested working on Windows 2012 R2 AD with unencrypted LDAP.